### PR TITLE
Make dnsconfd able to handle unbound start failure

### DIFF
--- a/bin/dnsconfd
+++ b/bin/dnsconfd
@@ -5,7 +5,6 @@ from dnsconfd import DnsconfdArgumentParser as argparser
 
 import signal
 import logging
-from gi.repository import GLib
 import dbus
 import dbus.mainloop.glib
 
@@ -20,11 +19,20 @@ if __name__ == "__main__":
 
     dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
     logging.basicConfig(level=logging.getLevelName(args.log_level))
-    name = dbus.service.BusName(args.dbus_name, dbus.SystemBus())
-    ctx = DnsconfdContext("/org/freedesktop/resolve1", name, vars(args))
-    signal.signal(signal.SIGTERM, lambda signum, frame: ctx.signal_handler(signum))
-    signal.signal(signal.SIGINT, lambda signum, frame: ctx.signal_handler(signum))
-    logging.info("Starting")
-    if not ctx.start_service():
-        exit(1)
-    GLib.MainLoop().run()
+
+    while True:
+        ctx = DnsconfdContext(vars(args))
+        # using lambdas here allows us to not use exit in DnsconfdContext class
+        signal.signal(signal.SIGTERM, lambda signum, frame: exit(ctx.signal_handler(signum)))
+        signal.signal(signal.SIGINT, lambda signum, frame: exit(ctx.signal_handler(signum)))
+        logging.info("Starting")
+        if not ctx.start_service():
+            exit(1)
+        ctx.process_events()
+        # neccessary as dbus would not allow us to recreate the instance, since the first would
+        # be still registered as handler
+        ctx.remove_from_connection()
+        if not ctx.was_reload_requested():
+            logging.info("Shutting down")
+            exit(ctx.stop())
+        logging.info("Performing reload of dnsconfd")

--- a/distribution/dnsconfd.service.d-unbound.conf
+++ b/distribution/dnsconfd.service.d-unbound.conf
@@ -1,3 +1,2 @@
-[Unit]
-Requires=unbound.service
-After=unbound.service
+[Service]
+ExecStopPost=-/usr/sbin/dnsconfd --dbus-name=org.freedesktop.resolve1 reload --plugin unbound

--- a/distribution/dnsconfd.spec
+++ b/distribution/dnsconfd.spec
@@ -4,7 +4,7 @@
 %global selinuxtype targeted
 
 Name:           dnsconfd                                                   
-Version:        0.0.2
+Version:        0.0.3
 Release:        1%{?dist}
 Summary:        Local DNS cache configuration daemon
 License:        MIT
@@ -84,6 +84,7 @@ bzip2 -9 %{modulename}.pp
 mkdir   -m 0755 -p %{buildroot}%{_datadir}/dbus-1/system.d/
 mkdir   -m 0755 -p %{buildroot}%{_sysconfdir}/unbound/conf.d/
 mkdir   -m 0755 -p %{buildroot}%{_unitdir}
+mkdir   -m 0755 -p %{buildroot}%{_unitdir}/unbound.service.d
 mkdir   -m 0755 -p %{buildroot}%{_sysconfdir}/sysconfig
 mkdir   -m 0755 -p %{buildroot}%{_sbindir}
 mkdir   -m 0755 -p %{buildroot}%{_var}/log/dnsconfd
@@ -92,7 +93,10 @@ mkdir   -m 0755 -p %{buildroot}/%{_mandir}/man8
 install -m 0644 -p %{SOURCE1} %{buildroot}%{_datadir}/dbus-1/system.d/com.redhat.dnsconfd.conf
 install -m 0644 -p %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/dnsconfd
 install -m 0644 -p %{SOURCE2} %{buildroot}%{_unitdir}/dnsconfd.service
-%dnl install -m 0644 -p %{SOURCE9} %{buildroot}%{_unitdir}/dnsconfd.service.d/unbound.conf
+
+# hook to inform us about unbound stop
+install -m 0644 -p %{SOURCE9} %{buildroot}%{_unitdir}/unbound.service.d/dnsconfd.conf
+
 install -m 0644 -p %{SOURCE10} %{buildroot}%{_sysconfdir}/unbound/conf.d/unbound.conf
 
 touch %{buildroot}%{_var}/log/dnsconfd/unbound.log
@@ -152,11 +156,14 @@ fi
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{modulename}
 
 %files unbound
-%dnl %{_unitdir}/dnsconfd.service.d/unbound.conf
+%{_unitdir}/unbound.service.d/dnsconfd.conf
 %config(noreplace) %{_sysconfdir}/unbound/conf.d/unbound.conf
 %ghost %{_var}/log/dnsconfd/unbound.log
 
 %changelog
+* Wed Jan 31 2024 Tomas Korbar <tkorbar@redhat.com> - 0.0.3-1
+- Release 0.0.3
+
 * Wed Jan 24 2024 Tomas Korbar <tkorbar@redhat.com> - 0.0.2-1
 - Release 0.0.2
 

--- a/dnsconfd/argument_parser.py
+++ b/dnsconfd/argument_parser.py
@@ -30,6 +30,14 @@ class DnsconfdArgumentParser(ArgumentParser):
                                               help="Print status if there is a running instance")
         status_parser.set_defaults(func=self._print_status)
 
+        reload_parser = subparsers.add_parser("reload",
+                                              help="Reload either partially or fully running instance of dnsconfd")
+        reload_parser.set_defaults(func=self._reload)
+
+        reload_parser.add_argument("--plugin",
+                                   default="",
+                                   help="Name of the plugin that should be reloaded")
+
         config_parser = subparsers.add_parser("config",
                                               help="Change configuration of service or host")
         config_parser.set_defaults(func=lambda: self.print_help())
@@ -59,3 +67,6 @@ class DnsconfdArgumentParser(ArgumentParser):
             self._parsed.log_level = os.environ.get("LOG_LEVEL", "INFO")
 
         return self._parsed
+
+    def _reload(self):
+        CLI_Commands.reload(self._parsed.dbus_name, self._parsed.plugin)

--- a/dnsconfd/cli_commands.py
+++ b/dnsconfd/cli_commands.py
@@ -34,7 +34,16 @@ class CLI_Commands:
             exit(1)
 
     @staticmethod
-    def unbound_config(enable: bool):
-        with open("dnsconfd.service.d-unbound.conf", "w") as f:
-            # TODO: have own plugin in NM
-            f.writelines([self.HEADER, "[main]\n", "dns=systemd-resolved\n", "rc-manager=unmanaged\n"])
+    def reload(dbus_name, plugin=None):
+        bus = dbus.SystemBus()
+        try:
+            dnsconfd_object = bus.get_object(dbus_name, "/org/freedesktop/resolve1")
+        except DBusException as e:
+            print(f"Dnsconfd is not listening on name {dbus_name}")
+            exit(1)
+        try:
+            print(dnsconfd_object.Reload(plugin, dbus_interface='org.freedesktop.resolve1.Dnsconfd'))
+        except DBusException as e:
+            print("Was not able to call Status method, check your DBus policy")
+            exit(1)
+        exit(0)

--- a/dnsconfd/configuration/interface_configuration.py
+++ b/dnsconfd/configuration/interface_configuration.py
@@ -25,6 +25,7 @@ class InterfaceConfiguration:
         self.dnssec = dnssec
         self.is_default = is_default
         self.interface_index = interface_index
+        self.finished = False
 
     def __str__(self) -> str:
         """ Create string representation of instance
@@ -54,6 +55,12 @@ class InterfaceConfiguration:
             return False
 
     def get_ifname(self) -> str:
+        """ Get interface name
+
+        :return: Name of the interface represented by this instance, if socket is unable
+                 to translate it, then string of index will be returned
+        :rtype: str
+        """
         try:
             return socket.if_indextoname(self.interface_index)
         except OSError as e:

--- a/dnsconfd/dnsconfd_context.py
+++ b/dnsconfd/dnsconfd_context.py
@@ -5,47 +5,182 @@ from dnsconfd.dns_managers import UnboundManager
 
 import signal
 import logging as lgr
-import sys
 import json
 import dbus.service
+from gi.repository import GLib
 
 class DnsconfdContext(dbus.service.Object):
-    def __init__(self, object_path, bus_name, config: dict):
-        super().__init__(object_path=object_path, bus_name=bus_name)
-        self.dns_mgr = None
+    def __init__(self, config: dict):
+        super().__init__(object_path="/org/freedesktop/resolve1",
+                         bus_name=dbus.service.BusName(config["dbus_name"], dbus.SystemBus()))
         self.my_address = config["listen_address"]
         self.sys_mgr = SystemManager(config["resolv_conf_path"], self.my_address)
         self.interfaces: dict[InterfaceConfiguration] = {}
+        self._main_loop = GLib.MainLoop()
 
-    def signal_handler(self, signum):
+        self._systemd_object = None
+
+        self.dns_mgr = None
+
+        # dictionary, systemd jobs -> manager instances of services they should start
+        self._start_jobs = {}
+        self._exit_code = 0
+
+    def signal_handler(self, signum: int) -> int:
+        """ Handle incoming signal and return appropriate exit code
+
+        :param signum: signal integer representation
+        :type signum: int
+        :return: Exit code
+        :rtype: int
+        """
         lgr.info(f"Caught signal {signal.strsignal(signum)}, shutting down")
+        return self.stop()
+
+    def _stop_execution(self, exit_code):
+        self._exit_code = exit_code
+        self._main_loop.quit()
+
+    def was_reload_requested(self) -> bool:
+        """ Get whether reload was requested
+
+        :return: True if reload was requested, otherwise False
+        :rtype: bool
+        """
+        return self._exit_code == 256
+
+    def _on_service_start_finished(self, *args):
+        jobid = int(args[0])
+        mgr_instance = self._start_jobs.pop(jobid, None)
+        if mgr_instance is not None:
+            lgr.debug(f"{args[2]} start job finished")
+            if len(self._start_jobs.keys()) == 0:
+                # we do not want to receive info about jobs anymore
+                dbus.Interface(self._systemd_object,
+                               "org.freedesktop.systemd1.Manager").Unsubscribe()
+            if args[3] != "done" and args[3] != "skipped":
+                lgr.error(f"{args[2]} unit failed to start, result: {args[3]}")
+                self._stop_execution(1)
+                return
+            GLib.timeout_add_seconds(1, lambda: self._service_status_poll(mgr_instance))
+
+    def _service_status_poll(self, mgr_instance: UnboundManager, counter = 0):
+        # better way to find out whether service is ready was not found
+        # TODO timeout or number of tries needs to be configurable here
+        if not mgr_instance.is_ready():
+            if counter == 3:
+                lgr.error(f"{mgr_instance.service_name} did not respond in time, stopping dnsconfd")
+                self._stop_execution(1)
+                return False
+            lgr.debug(f"{mgr_instance.service_name} still not ready, waiting")
+            GLib.timeout_add_seconds(1,
+                                     lambda: self._service_status_poll(mgr_instance,
+                                                                       counter=counter+1))
+        else:
+            mgr_instance.start_finished = True
+            self._update()
+        # we need to return False so this event is removed from loop
+        return False
+
+    def _start_unit(self):
+        lgr.info(f"Starting {self.dns_mgr.service_name}")
+        interface = dbus.Interface(self._systemd_object, "org.freedesktop.systemd1.Manager")
+        try:
+            return int(interface.ReloadOrRestartUnit(f"{self.dns_mgr.service_name}.service",
+                                                     "replace").split('/')[-1])
+        except dbus.DBusException as e:
+            lgr.error("Was not able to call org.freedesktop.systemd1.Manager.ReloadOrRestartUnit"
+                      + ", check your policy")
+            lgr.error(str(e))
+        return None
+        # start or restart service
+
+    def _stop_unit(self):
+        lgr.info(f"Stoping {self.dns_mgr.service_name}")
+        interface = dbus.Interface(self._systemd_object, "org.freedesktop.systemd1.Manager")
+        try:
+            interface.StopUnit(f"{self.dns_mgr.service_name}.service", "replace")
+            return True
+        except dbus.DBusException as e:
+            lgr.error("Was not able to call org.freedesktop.systemd1.Manager.StopUnit"
+                      + ", check your policy")
+            lgr.error(str(e))
+        return False
+        # stop service
+
+    def _subscribe_systemd_signals(self):
+        try:
+            interface = dbus.Interface(self._systemd_object, "org.freedesktop.systemd1.Manager")
+            interface.Subscribe()
+            interface.connect_to_signal("JobRemoved", self._on_service_start_finished)
+            return True
+        except dbus.DBusException as e:
+            lgr.error("Systemd is not listening on name org.freedesktop.systemd1")
+            lgr.error(str(e))
+        return False
+
+    def _connect_systemd(self):
+        try:
+            self._systemd_object = dbus.SystemBus().get_object('org.freedesktop.systemd1',
+                                                               '/org/freedesktop/systemd1')
+            return True
+        except dbus.DBusException as e:
+            lgr.error("Systemd is not listening on name org.freedesktop.systemd1")
+            lgr.error(str(e))
+        return False
+
+    def stop(self) -> int:
+        """ Revert resolvconf changes and stop caching service
+
+        :return: Exit code that should be used
+        :rtype: int
+        """
         if self.sys_mgr.resolvconf_altered:
             self.sys_mgr.revert_resolvconf()
-        if self.dns_mgr is not None:
-            self.dns_mgr.stop()
-            self.dns_mgr.clean()
-        sys.exit(0)
+        if not self._stop_unit():
+            return 1
+        return self._exit_code
 
-    def start_service(self):
+    def start_service(self) -> bool:
+        """ Perform preparation and start DNS caching service
+
+        :return: True if success, otherwise False
+        :rtype: bool
+        """
+        if not self._connect_systemd() or not self._subscribe_systemd_signals():
+            return False
+        # TODO we will configure this in configuration
         self.dns_mgr = UnboundManager()
         self.dns_mgr.configure(self.my_address)
-        if not self.dns_mgr.start():
+        service_start_job = self._start_unit()
+        if service_start_job is None:
             return False
+        self._start_jobs[service_start_job] = self.dns_mgr
+        # end of part that will be configured
         self.sys_mgr.setResolvconf()
         return True
 
-    def log_servers(self, ifname: str, servers: list[ServerDescription]):
-        """Log user friendly representation of servers."""
+    def process_events(self):
+        self._main_loop.run()
+
+    def _log_servers(self, ifname: str, servers: list[ServerDescription]):
+        """ Log string representation of list of ServerDescription instances
+
+        :param ifname: Name of interface associated with servers
+        :type ifname: str
+        :param servers: list of server descriptions associated with the interface
+        :type servers: list[ServerDescription]
+        """
         nice_servers = ServerDescription.servers_string(servers)
         lgr.info(f"Incoming DNS servers on {ifname}: {nice_servers}")
 
-    def ifprio(self, interface_cfg: InterfaceConfiguration):
+    def _ifprio(self, interface_cfg: InterfaceConfiguration) -> int:
         if interface_cfg.is_interface_wireless():
             lgr.debug(f"Interface {interface_cfg.interface_index} is wireless")
             return 50
         return 100
 
-    def iface_config(self, interface_index: int):
+    def _iface_config(self, interface_index: int):
         """Get existing or create new default interface configuration."""
         return self.interfaces.setdefault(interface_index, InterfaceConfiguration(interface_index))
 
@@ -63,34 +198,35 @@ class DnsconfdContext(dbus.service.Object):
                          in_signature='ia(iay)', out_signature='')
     def SetLinkDNS(self, interface_index: int, addresses: list[(int, bytearray)]):
         lgr.debug(f"SetLinkDNS called, interface index: {interface_index}, addresses: {addresses}")
-        interface_cfg = self.iface_config(interface_index)
-        prio = self.ifprio(interface_cfg)
+        interface_cfg = self._iface_config(interface_index)
+        prio = self._ifprio(interface_cfg)
         servers = [ServerDescription(fam, addr, priority=prio) for fam, addr in addresses]
         interface_cfg.servers = servers
-        self.log_servers(interface_cfg.get_ifname(), servers)
+        self._log_servers(interface_cfg.get_ifname(), servers)
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
                          in_signature='ia(iayqs)', out_signature='')
     def SetLinkDNSEx(self, interface_index: int, addresses: list[(int, bytearray, int, str)]):
         lgr.debug(f"SetLinkDNSEx called, interface index: {interface_index}, addresses: {addresses}")
-        interface_cfg = self.iface_config(interface_index)
-        prio = self.ifprio(interface_cfg)
+        interface_cfg = self._iface_config(interface_index)
+        prio = self._ifprio(interface_cfg)
         servers = [ServerDescription(fam, addr, port, sni, prio) for fam, addr, port, sni in addresses]
         interface_cfg.servers = servers
-        self.log_servers(interface_cfg.get_ifname(), servers)
+        self._log_servers(interface_cfg.get_ifname(), servers)
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
                          in_signature='ia(sb)', out_signature='')
     def SetLinkDomains(self, interface_index: int, domains: list[(str, bool)]):
         lgr.debug(f"SetLinkDomains called, interface index: {interface_index}, domains: {domains}")
-        interface_cfg = self.iface_config(interface_index)
+        interface_cfg = self._iface_config(interface_index)
+        interface_cfg.finished = False
         interface_cfg.domains = [(str(domain), bool(is_routing)) for domain, is_routing in domains]
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
                          in_signature='ib', out_signature='')
     def SetLinkDefaultRoute(self, interface_index: int, is_default: bool):
         lgr.debug(f"SetLinkDefaultRoute called, interface index: {interface_index}, is_default: {is_default}")
-        interface_cfg = self.iface_config(interface_index)
+        interface_cfg = self._iface_config(interface_index)
         interface_cfg.is_default = is_default
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
@@ -110,14 +246,19 @@ class DnsconfdContext(dbus.service.Object):
         lgr.debug(f"SetLinkDNSOverTLS called, interface index: {interface_index}, mode: '{mode}'")
         interface_cfg: InterfaceConfiguration = self.interfaces[interface_index]
         interface_cfg.dns_over_tls = True if mode == "yes" or mode == "opportunistic" else False
-        # now let dns manager deal with update in its own way
-        self._update()
+        interface_cfg.finished = True
+        # zero keys in start jobs means that we consider unbound healthy and running
+        if self.dns_mgr.start_finished:
+            # now let dns manager deal with update in its own way
+            self._update()
+        else:
+            lgr.info("A service start job is running, derefering update")
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
                          in_signature='is', out_signature='')
     def SetLinkDNSSEC(self, interface_index: int, mode: str):
         lgr.debug(f"SetLinkDNSSEC called and ignored, interface index: {interface_index}, mode: {mode}")
-        interface_cfg = self.iface_config(interface_index)
+        interface_cfg = self._iface_config(interface_index)
         interface_cfg.dns_over_tls = False if mode == "no" or mode == "allow-downgrade" else True
 
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Manager',
@@ -139,13 +280,35 @@ class DnsconfdContext(dbus.service.Object):
     @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Dnsconfd',
                          in_signature='', out_signature='s')
     def Status(self):
-        lgr.debug('Handling request for status')
-        status = {}
-        status["service"] = self.dns_mgr.service_name if self.dns_mgr is not None else ""
-        status["config"] = self.dns_mgr.get_status() if self.dns_mgr is not None else ""
+        lgr.debug("Handling request for status")
+        status = {"service": self.dns_mgr.service_name, "config": self.dns_mgr.get_status()}
         return json.dumps(status)
 
+    @dbus.service.method(dbus_interface='org.freedesktop.resolve1.Dnsconfd',
+                         in_signature='s', out_signature='')
+    def Reload(self, plugin: str):
+        lgr.info(f"Received request for reload{' of plugin ' + plugin if plugin != '' else ''}")
+        if plugin == self.dns_mgr.service_name:
+            if not self.dns_mgr.start_finished:
+                lgr.info("Plugin does not allow reload at this time")
+                return
+            self._reload_plugin()
+        elif plugin != '':
+            lgr.warning("Plugin is not currently active and thus can not be reloaded")
+        else:
+            # exit codes can be 0-255 that means 256 can be our internal value informing
+            # loop about reload request
+            self._stop_execution(256)
+
+    def _reload_plugin(self):
+        self.dns_mgr.clear_state()
+        GLib.timeout_add_seconds(1, lambda: self._service_status_poll(self.dns_mgr))
+
     def _update(self):
+        for config in self.interfaces.values():
+            if not config.finished:
+                lgr.debug("Not all interfaces are complete, derefering update")
+                return
         new_zones_to_servers = {}
 
         search_domains = []

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='dnsconfd',
-    version='0.0.2',
+    version='0.0.3',
     install_requires=[
         'dbus-python',
     ],

--- a/tests/build_package.sh
+++ b/tests/build_package.sh
@@ -5,5 +5,5 @@ set -e
 python3 setup.py sdist -d ./distribution
 pushd distribution
 fedpkg --release=f39 mockbuild
-mv ./results_dnsconfd/0.0.2/1.fc39/*.noarch.rpm ../tests
+mv ./results_dnsconfd/0.0.3/1.fc39/*.noarch.rpm ../tests
 popd

--- a/tests/dbus-status/test.sh
+++ b/tests/dbus-status/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
 
     rlPhaseStartTest
         rlServiceStart dnsconfd
-        sleep 2
+        sleep 3
         rlRun "sudo -u dummy dnsconfd --dbus-name=$DBUS_NAME status | grep unbound" 0 "Verifying status of dnsconfd as dummy user"
         # we can not simply check for a AVC until chrony issue is fixed
         rlRun "sudo -u dummy dbus-send --system --dest=org.freedesktop.resolve1 --print-reply\

--- a/tests/reload/expected_status.json
+++ b/tests/reload/expected_status.json
@@ -1,0 +1,1 @@
+{"service": "unbound", "config": {".": ["192.168.6.3"]}}

--- a/tests/reload/main.fmf
+++ b/tests/reload/main.fmf
@@ -1,0 +1,7 @@
+summary: Start container, set 1 DNS server, reload dnsconfd and verify status and correct address resolution
+test: ./test.sh
+framework: beakerlib
+recommend:
+  - podman
+tag:
+  - integration

--- a/tests/reload/test.sh
+++ b/tests/reload/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+DBUS_NAME=org.freedesktop.resolve1
+ORIG_DIR=$(pwd)
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "podman network create dnsconfd_network -d=bridge --gateway=192.168.6.1 --subnet=192.168.6.0/24"
+        # dns=none is neccessary, because otherwise resolv.conf is created and
+        # mounted by podman as read-only
+        rlRun "dnsconfd_cid=\$(podman run -d --dns='none' --network dnsconfd_network:ip=192.168.6.2 dnsconfd_testing:latest)" 0 "Starting dnsconfd container"
+        rlRun "dnsmasq_cid=\$(podman run -d --dns='none' --network dnsconfd_network:ip=192.168.6.3 localhost/dnsconfd_utilities:latest dnsmasq_entry.sh --listen-address=192.168.6.3 --address=/address.test.com/192.168.6.3)" 0 "Starting dnsmasq container"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid nmcli connection mod eth0 ipv4.dns 192.168.6.3" 0 "Adding dns server to NM active profile"
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid dnsconfd --dbus-name=$DBUS_NAME reload"
+        sleep 10
+        # unfortunately it is neccessary to force NetworkManager to send us configuration
+        rlRun "podman exec $dnsconfd_cid systemctl reload NetworkManager" 0 "reload NM"
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid dnsconfd --dbus-name=$DBUS_NAME status > status1" 0 "Getting status of dnsconfd"
+        rlAssertNotDiffer status1 $ORIG_DIR/expected_status.json
+        rlRun "podman exec $dnsconfd_cid getent hosts address.test.com | grep 192.168.6.3" 0 "Verifying correct address resolution"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "podman stop -t 2 $dnsconfd_cid $dnsmasq_cid" 0 "Stopping containers"
+        rlRun "podman container rm $dnsconfd_cid $dnsmasq_cid" 0 "Removing containers"
+        rlRun "podman network rm dnsconfd_network" 0 "Removing networks"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/start_issue/main.fmf
+++ b/tests/start_issue/main.fmf
@@ -1,0 +1,7 @@
+summary: Start container, break unbound and verify that dnsconfd shuts down
+test: ./test.sh
+framework: beakerlib
+recommend:
+  - podman
+tag:
+  - integration

--- a/tests/start_issue/test.sh
+++ b/tests/start_issue/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+DBUS_NAME=org.freedesktop.resolve1
+ORIG_DIR=$(pwd)
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "set -o pipefail"
+        rlRun "podman network create dnsconfd_network -d=bridge --gateway=192.168.6.1 --subnet=192.168.6.0/24"
+        # dns=none is neccessary, because otherwise resolv.conf is created and
+        # mounted by podman as read-only
+        rlRun "dnsconfd_cid=\$(podman run -d --dns='none' --network dnsconfd_network:ip=192.168.6.2 dnsconfd_testing:latest)" 0 "Starting dnsconfd container"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid systemctl stop dnsconfd" 0 "stop dnsconfd"
+        rlRun "podman exec $dnsconfd_cid sed -i 's/ExecStart=.*/ExecStart=false/g' /usr/lib/systemd/system/unbound.service" 0 "breaking unbound"
+        rlRun "podman exec $dnsconfd_cid systemctl daemon-reload" 0 "reload systemd units"
+        rlRun "podman exec $dnsconfd_cid systemctl start dnsconfd" 0 "start dnsconfd"
+        sleep 6
+        rlRun "podman exec $dnsconfd_cid journalctl -u dnsconfd | grep 'unbound did not respond in time'" 0 "Checking dnsconfd logs"
+        rlRun "podman exec $dnsconfd_cid systemctl status dnsconfd" 3 "Verify that dnsconfd is stopped"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "podman stop -t 2 $dnsconfd_cid" 0 "Stopping containers"
+        rlRun "podman container rm $dnsconfd_cid" 0 "Removing containers"
+        rlRun "podman network rm dnsconfd_network" 0 "Removing networks"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/unbound-stop-recovery/expected_status.json
+++ b/tests/unbound-stop-recovery/expected_status.json
@@ -1,0 +1,1 @@
+{"service": "unbound", "config": {".": ["192.168.6.3"]}}

--- a/tests/unbound-stop-recovery/main.fmf
+++ b/tests/unbound-stop-recovery/main.fmf
@@ -1,0 +1,7 @@
+summary: Start container, set 1 DNS server and verify that dnsconfd handled the update, stop unbound, let dnsconfd bring it back up and verify again
+test: ./test.sh
+framework: beakerlib
+recommend:
+  - podman
+tag:
+  - integration

--- a/tests/unbound-stop-recovery/test.sh
+++ b/tests/unbound-stop-recovery/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+DBUS_NAME=org.freedesktop.resolve1
+ORIG_DIR=$(pwd)
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "podman network create dnsconfd_network -d=bridge --gateway=192.168.6.1 --subnet=192.168.6.0/24"
+        # dns=none is neccessary, because otherwise resolv.conf is created and
+        # mounted by podman as read-only
+        rlRun "dnsconfd_cid=\$(podman run -d --dns='none' --network dnsconfd_network:ip=192.168.6.2 dnsconfd_testing:latest)" 0 "Starting dnsconfd container"
+        rlRun "dnsmasq_cid=\$(podman run -d --dns='none' --network dnsconfd_network:ip=192.168.6.3 localhost/dnsconfd_utilities:latest dnsmasq_entry.sh --listen-address=192.168.6.3 --address=/address.test.com/192.168.6.3)" 0 "Starting dnsmasq container"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid nmcli connection mod eth0 ipv4.dns 192.168.6.3" 0 "Adding dns server to NM active profile"
+        sleep 2
+        rlRun "podman exec $dnsconfd_cid dnsconfd --dbus-name=$DBUS_NAME status > status1" 0 "Getting status of dnsconfd"
+        rlAssertNotDiffer status1 $ORIG_DIR/expected_status.json
+        rlRun "podman exec $dnsconfd_cid getent hosts address.test.com | grep 192.168.6.3" 0 "Verifying correct address resolution"
+        # the exit code needs to be 0-1 because during handling of stop, unbound queues start job and replaces the stop
+        # so it cancells it
+        rlRun "podman exec $dnsconfd_cid systemctl restart unbound" 0 "Restarting unbound"
+        sleep 5
+        rlRun "podman exec $dnsconfd_cid getent hosts address.test.com | grep 192.168.6.3" 0 "Verifying correct address resolution after unbound recovery"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "podman stop -t 2 $dnsconfd_cid $dnsmasq_cid" 0 "Stopping containers"
+        rlRun "podman container rm $dnsconfd_cid $dnsmasq_cid" 0 "Removing containers"
+        rlRun "podman network rm dnsconfd_network" 0 "Removing networks"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
After 3 attempts to verify Unbound's status, the plugin will notify main loop to stop handling events and exit.