### PR TITLE
Include README in created package

### DIFF
--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/distribution/dnsconfd.spec
+++ b/distribution/dnsconfd.spec
@@ -143,6 +143,7 @@ fi
 %attr(0755,root,root) %{_var}/log/dnsconfd
 %{_mandir}/man8/dnsconfd.8*
 %ghost %{_sysusersdir}/dnsconfd.conf
+%doc README.md
 
 %files selinux
 %{_datadir}/selinux/packages/%{selinuxtype}/%{modulename}.pp.*


### PR DESCRIPTION
It contains instructions, which we do not have in any other place. I think we need it there for copy&pasting.