### PR TITLE
Fix search domain addition to resolv.conf

### DIFF
--- a/dnsconfd/fsm/dnsconfd_context.py
+++ b/dnsconfd/fsm/dnsconfd_context.py
@@ -700,7 +700,6 @@ class DnsconfdContext:
             self.lgr.debug(f"Processing interface {interface}")
             interface: InterfaceConfiguration
             interface_zones = []
-            search_domains = []
             for dom in interface.domains:
                 interface_zones.append(dom[0])
                 if not dom[1]:

--- a/tests/dhcpd-common.conf
+++ b/tests/dhcpd-common.conf
@@ -2,7 +2,6 @@ subnet 192.168.6.0 netmask 255.255.255.0 {
         option routers                  192.168.6.1;
         option subnet-mask              255.255.255.0;
         option domain-name              "test.com";
-        option domain-search            "test.com";
         option domain-name-servers      192.168.6.3, 192.168.6.4;
         range 192.168.6.2 192.168.6.3;
 }

--- a/tests/vpn/test.sh
+++ b/tests/vpn/test.sh
@@ -42,6 +42,7 @@ rlJournalStart
         rlRun "podman exec $dnsconfd_cid dnsconfd --dbus-name=$DBUS_NAME status --json > status2" 0 "Getting status of dnsconfd"
         rlAssertNotDiffer status2 $ORIG_DIR/expected_status2.json
         rlRun "podman exec $dnsconfd_cid getent hosts dummy | grep 192.168.6.5" 0 "Verifying correct address resolution"
+        rlRun "podman exec $dnsconfd_cid getent hosts second-address | grep 192.168.6.4" 0 "Verifying correct address resolution"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Typo was present which prevented more than a one search domains to be put into resolv.conf. This commit fixes the issue.

Fix: #45