### PR TITLE
Make certification_authority option check by default for dns store

### DIFF
--- a/distribution/dnsconfd-config.8
+++ b/distribution/dnsconfd-config.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-config" "8" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd-config" "8" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-reload.8
+++ b/distribution/dnsconfd-reload.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-reload" "8" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd-reload" "8" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-status.8
+++ b/distribution/dnsconfd-status.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-status" "8" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd-status" "8" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-update.8
+++ b/distribution/dnsconfd-update.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-status" "8" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd-status" "8" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 
@@ -29,7 +29,7 @@ Available fields of JSON servers are:
  \(bu \fBport\fP optional, port on which server is listening. If not given then 53 is used for plain protocol and 853 for DoT
  \(bu \fBrouting_domains\fP optional, list of strings with the domain name whose members will be resolved only by this or other servers with the same domain entry
  \(bu \fBsearch_domains\fP optional, list of strings with the domains that should be used for host-name lookup
- \(bu \fBinterface\fP optional, integer indicating if server can be used only through interface with this interface index.
+ \(bu \fBinterface\fP optional, string indicating if server can be used only through interface with this interface name.
  \(bu \fBdnssec\fP optional, boolean indicating whether this server supports dnssec or not
  \(bu \fBnetworks\fP optional, list of strings representing networks whose reverse dns records must be resolved by this server
  \(bu \fBconnection-uuid\fP optional, string uuid of the connection associated with server in NetworkManager
@@ -57,9 +57,9 @@ See examples section for further description.
 Integer representing resolving mode Dnsconfd should work in.
 
 Valid values are:
- \(bu \fB0\fP - Free, all available server can be used for resolving of all names
- \(bu \fB1\fP - Global restrictive, only global servers (not bound to interface) can be used for resolving of all names. Bound servers can resolve only subdomains
- \(bu \fB2\fP - Full restrictive, only global servers will be used for resolving
+ \(bu \fB0\fP - backup, all available server can be used for resolving of all names
+ \(bu \fB1\fP - prefer, only global servers (not bound to interface) can be used for resolving of all names. Bound servers can resolve only subdomains
+ \(bu \fB2\fP - exclusive, only global servers will be used for resolving
 
 .IP "-h, --help"
 Show help message and exit

--- a/distribution/dnsconfd.8
+++ b/distribution/dnsconfd.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd" "8" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd" "8" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 
@@ -18,7 +18,7 @@ and translates its use to dns service's configuration.
 .IP "-h, --help"
 Show help message and exit
 .IP "--dbus-name DBUS_NAME"
-DBUS name that dnsconfd should use, default org.freedesktop.resolve1
+DBUS name that dnsconfd should use, default com.redhat.dnsconfd
 .IP "--log-level {DEBUG,INFO,WARN}"
 Log level of dnsconfd, default INFO
 .IP "--resolv-conf-path RESOLV_CONF_PATH"
@@ -53,7 +53,11 @@ tcp:myhost.example.com:514
 Dnsconfd will write logs into specified file, not used by default
 .IP "--api-choice"
 Dnsconfd will switch between APIs. Allowed options are resolve1 and dnsconfd.
-Default is resolve1
+Default is dnsconfd
+.IP "--certification-authority"
+Space separated list of CA bundles used for encrypted protocols as default
+when no custom CA was specified. The first one that can be accessed will be
+used, default /etc/pki/dns/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 .SH "EXIT STATUS"
 

--- a/distribution/dnsconfd.conf.5
+++ b/distribution/dnsconfd.conf.5
@@ -1,4 +1,4 @@
-.TH "dnsconfd.conf" "5" "13 Feb 2025" "dnsconfd-1.7.1" ""
+.TH "dnsconfd.conf" "5" "19 Feb 2025" "dnsconfd-1.7.2" ""
 
 .SH NAME
 
@@ -11,7 +11,7 @@ Dnsconfd.conf is YAML formatted configuration file altering behaviour of Dnsconf
 .SH OPTIONS
 
 .IP "dbus_name"
-DBUS name that dnsconfd should use, default org.freedesktop.resolve1
+DBUS name that dnsconfd should use, default com.redhat.dnsconfd
 .IP "log_level"
 Log level of dnsconfd, default INFO
 .IP "resolv_conf_path"
@@ -28,7 +28,7 @@ Enable dnssec record validation, default no
 Dnsconfd will submit necessary routes to routing manager, default yes
 .IP "api_choice"
 Dnsconfd will switch between APIs. Allowed options are resolve1 and dnsconfd.
-Default is resolve1
+Default is dnsconfd
 .IP stderr_log
 Dnsconfd will write logs into stderr, default yes
 .IP journal_log
@@ -44,6 +44,10 @@ Absolute path to a bundle of certification authorities that will be used
 when no custom were specified.
 .IP "static_servers"
 List of servers that should be configured, default is empty
+.IP "certification_authority"
+Space separated list of CA bundles used for encrypted protocols as default
+when no custom CA was specified. The first one that can be accessed will be
+used, default /etc/pki/dns/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 Available attributes of servers are:
 

--- a/distribution/dnsconfd.spec
+++ b/distribution/dnsconfd.spec
@@ -2,7 +2,7 @@
 %global selinuxtype targeted
 
 Name:           dnsconfd
-Version:        1.7.1
+Version:        1.7.2
 Release:        1%{?dist}
 Summary:        Local DNS cache configuration daemon
 License:        MIT
@@ -236,6 +236,9 @@ fi
 %{_prefix}/lib/dracut/modules.d/99dnsconfd
 
 %changelog
+* Thu Feb 19 2025 Tomas Korbar <tkorbar@redhat.com> - 1.7.2-1
+- Release 1.7.2
+
 * Thu Feb 13 2025 Tomas Korbar <tkorbar@redhat.com> - 1.7.1-1
 - Release 1.7.1
 

--- a/dnsconfd/configuration/dnsconfd_argument_parser.py
+++ b/dnsconfd/configuration/dnsconfd_argument_parser.py
@@ -104,9 +104,11 @@ class DnsconfdArgumentParser(ArgumentParser):
                          "dnsconfd",
                          validation=r"resolve1|dnsconfd"),
             Option("certification_authority",
-                   "This CA will be used for encrypted protocols"
-                   " as default when no custom CA was specified",
-                   "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+                   "Space separated list of CA bundles used for "
+                   "encrypted protocols as default when no custom CA was "
+                   "specified. The first one that can be accessed will be "
+                   "used",
+                   "/etc/pki/dns/extracted/pem/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
         ]
 
     def add_arguments(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, Tomas Korbar, Petr Mensik'
 author = 'Tomas Korbar, Petr Mensik'
 
 # The full version, including alpha/beta/rc tags
-release = '1.7.1'
+release = '1.7.2'
 
 
 # -- General network_objects ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='dnsconfd',
-    version='1.7.1',
+    version='1.7.2',
     install_requires=[
         'dbus-python',
         'pyyaml'

--- a/tests/dns-over-tls/test.sh
+++ b/tests/dns-over-tls/test.sh
@@ -35,9 +35,9 @@ rlJournalStart
         rlRun "podman exec $dnsconfd_cid getent hosts server.example.com | grep 192.168.6.5" 0 "Verifying correct address resolution"
         # custom CA testing
         rlRun "podman exec $dnsconfd_cid mkdir -p /etc/pki/dns/extracted/pem" 0 "Create dns CA directory"
-        rlRun "podman exec $dnsconfd_cid mv /etc/pki/ca-trust/source/anchors/ca_cert.pem /etc/pki/dns/extracted/pem/" 0 "Move certificate"
+        rlRun "podman exec $dnsconfd_cid mv /etc/pki/ca-trust/source/anchors/ca_cert.pem /etc/pki/dns/extracted/pem/tls-ca-bundle.pem" 0 "Move certificate"
         rlRun "podman exec $dnsconfd_cid update-ca-trust extract" 0 "Rebuild global store without custom certificate"
-        rlRun "podman exec $dnsconfd_cid /bin/bash -c 'printf \"[global-dns]\\ncertification-authority=/etc/pki/dns/extracted/pem/ca_cert.pem\\n[global-dns-domain-*]\\nservers=dns+tls://192.168.6.3#named\\n\" >> /etc/NetworkManager/conf.d/dnsconfd.conf'"
+        rlRun "podman exec $dnsconfd_cid /bin/bash -c 'printf \"[global-dns]\\n[global-dns-domain-*]\\nservers=dns+tls://192.168.6.3#named\\n\" >> /etc/NetworkManager/conf.d/dnsconfd.conf'"
         rlRun "podman exec $dnsconfd_cid nmcli g reload" 0 "Reloading NetworkManager"
         rlRun "podman exec $dnsconfd_cid systemctl restart dnsconfd" 0 "Flush cache with restart to ensure we do not get false negative"
         rlRun "podman exec $dnsconfd_cid nmcli connection mod eth0 ipv4.dns ''" 0 "Removing dns server from NM active profile"

--- a/tests/initramfs_support/test.sh
+++ b/tests/initramfs_support/test.sh
@@ -19,7 +19,7 @@ rlJournalStart
               rlRun "cp ./test-resolve.service /lib/dracut/modules.d/99test-resolve"
               rlRun "cp ./test-resolve.service /usr/lib/systemd/system/test-resolve.service"
               rlRun "sed -i 's/\(GRUB_CMDLINE_LINUX.*=\".*\)\"/\1 rd.neednet rd.net.dns=dns+tls:\/\/${TMT_GUESTS[server.hostname]}#named ip=dhcp\"/g' /etc/default/grub"
-              rlRun "grubby --update-kernel=/boot/vmlinuz-$(uname -r) --args=\"rd.neednet rd.net.dns=dns+tls://${TMT_GUESTS[server.hostname]}#named ip=dhcp\""
+              rlRun "grubby --update-kernel=/boot/vmlinuz-$(uname -r) --args=\"rd.neednet rd.net.dns=dns+tls://${TMT_GUESTS[server.hostname]}#named ip=dhcp rd.net.dns-global-mode=exclusive rd.net.dns-backend=dnsconfd\""
               rlRun "dracut --force" 0 "Rebuild initramfs"
               rlRun "grub2-mkconfig -o /boot/grub2/grub.cfg"
               rlRun "tmt-reboot" 0 "Reboot the machine"

--- a/unittests/configuration/test_dnsconfd_argument_parser.py
+++ b/unittests/configuration/test_dnsconfd_argument_parser.py
@@ -51,7 +51,8 @@ def filled_conf_instance():
                                       'handle_routing': False,
                                       'config_file': '/etc/dnsconfd.conf',
                                       'api_choice': 'dnsconfd',
-                                      'certification_authority': '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+                                      'certification_authority': '/etc/pki/dns/extracted/pem/tls-ca-bundle.pem '
+                                                                 '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
                                       'static_servers': [],
                                       'ignore_api': False}),
     (["--log-level", "DEB"], ValueError, {}),
@@ -85,7 +86,8 @@ def test_parse(args, raised_exception, parsed, empty_conf_instance):
       'handle_routing': False,
       'config_file': '/etc/dnsconfd.conf',
       'api_choice': 'dnsconfd',
-      'certification_authority': '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+      'certification_authority': '/etc/pki/dns/extracted/pem/tls-ca-bundle.pem '
+                                 '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
       'static_servers': [],
       'ignore_api': True}),
     (["--listen-address", "127.0.0.4"],
@@ -104,7 +106,8 @@ def test_parse(args, raised_exception, parsed, empty_conf_instance):
       'handle_routing': False,
       'config_file': '/etc/dnsconfd.conf',
       'api_choice': 'dnsconfd',
-      'certification_authority': '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
+      'certification_authority': '/etc/pki/dns/extracted/pem/tls-ca-bundle.pem '
+                                 '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',
       'static_servers': [],
       'ignore_api': True}),
 ])


### PR DESCRIPTION
certification_authority is now space separated list of paths that are respectively checked and the first one is used if no other value is supplied by the API