### PR TITLE
Fix hang on upgrade and bump release to 2.2.0

### DIFF
--- a/distribution/dnsconfd-config.8
+++ b/distribution/dnsconfd-config.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-config" "8" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd-config" "8" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-reload.8
+++ b/distribution/dnsconfd-reload.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-reload" "8" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd-reload" "8" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-status.8
+++ b/distribution/dnsconfd-status.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-status" "8" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd-status" "8" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd-update.8
+++ b/distribution/dnsconfd-update.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd-update" "8" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd-update" "8" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd.8
+++ b/distribution/dnsconfd.8
@@ -1,4 +1,4 @@
-.TH "dnsconfd" "8" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd" "8" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd.conf.5
+++ b/distribution/dnsconfd.conf.5
@@ -1,4 +1,4 @@
-.TH "dnsconfd.conf" "5" "13 Mar 2026" "dnsconfd-2.1.0" ""
+.TH "dnsconfd.conf" "5" "12 May 2026" "dnsconfd-2.2.0" ""
 
 .SH NAME
 

--- a/distribution/dnsconfd.spec
+++ b/distribution/dnsconfd.spec
@@ -172,7 +172,7 @@ fi
 %systemd_preun dnsconfd-unbound-control.path
 
 %postun unbound
-%systemd_postun_with_restart dnsconfd-unbound-control.path
+%systemd_postun dnsconfd-unbound-control.path
 
 %post
 %systemd_post %{name}.service

--- a/distribution/dnsconfd.spec
+++ b/distribution/dnsconfd.spec
@@ -2,7 +2,7 @@
 %global selinuxtype targeted
 
 Name:           dnsconfd
-Version:        2.1.0
+Version:        2.2.0
 Release:        1%{?dist}
 Summary:        Local DNS cache configuration daemon
 License:        MIT

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('dnsconfd', 'c', version: '2.1.0')
+project('dnsconfd', 'c', version: '2.2.0')
 
 executable(
     'dnsconfd',

--- a/src/configuration_parsing/global_options.c
+++ b/src/configuration_parsing/global_options.c
@@ -17,7 +17,7 @@
 #include "update_command.h"
 
 error_t argp_err_exit_status = EXIT_BAD_ARGUMENTS;
-const char *argp_program_version = "dnsconfd 2.1.0";
+const char *argp_program_version = "dnsconfd 2.2.0";
 const char *argp_program_bug_address = "<tkorbar@redhat.com>";
 static char doc[] = "local DNS cache configuration daemon";
 static char args_doc[] = "[--help] [--log-level LOG_LEVEL] [--stderr-log | --no-stderr-log] "

--- a/tests/build_package.sh
+++ b/tests/build_package.sh
@@ -3,9 +3,9 @@
 set -e
 
 tempdir=$(mktemp -d)
-tar -czvf $tempdir/dnsconfd-2.1.0.tar.gz --transform 's,^\./,dnsconfd-2.1.0/,' .
+tar -czvf $tempdir/dnsconfd-2.2.0.tar.gz --transform 's,^\./,dnsconfd-2.2.0/,' .
 mkdir SOURCES
-cp ./distribution/dnsconfd.sysusers $tempdir/dnsconfd-2.1.0.tar.gz ./SOURCES
+cp ./distribution/dnsconfd.sysusers $tempdir/dnsconfd-2.2.0.tar.gz ./SOURCES
 # there is a hidden side effect of bb and that is that it copies sources from
 # SOURCES directory into binary rpms, however if they are missing, they
 # are not copied and scriptlets are left without them

--- a/tests/build_package.sh
+++ b/tests/build_package.sh
@@ -2,14 +2,14 @@
 
 set -e
 
-tempdir=$(mktemp -d)
-tar -czvf $tempdir/dnsconfd-2.2.0.tar.gz --transform 's,^\./,dnsconfd-2.2.0/,' .
+tempdir="$(mktemp -d)"
+tar -czvf "$tempdir/dnsconfd-2.2.0.tar.gz" --transform 's,^\./,dnsconfd-2.2.0/,' .
 mkdir SOURCES
-cp ./distribution/dnsconfd.sysusers $tempdir/dnsconfd-2.2.0.tar.gz ./SOURCES
+cp ./distribution/dnsconfd.sysusers "$tempdir/dnsconfd-2.2.0.tar.gz" ./SOURCES
 # there is a hidden side effect of bb and that is that it copies sources from
 # SOURCES directory into binary rpms, however if they are missing, they
 # are not copied and scriptlets are left without them
 rpmbuild --define "_topdir $PWD" --define "with_asan 1" -bb distribution/dnsconfd.spec
 find ./RPMS -name "*.rpm" -exec cp "{}" ./tests \;
 rm -rf BUILDROOT RPMS SRPMS SOURCES
-rm -rf $tempdir
+rm -rf "$tempdir"

--- a/tests/upgrade_restart/main.fmf
+++ b/tests/upgrade_restart/main.fmf
@@ -1,0 +1,8 @@
+summary: Verify that daemon-reload + service restart does not hang due to path unit race
+test: ./test.sh
+framework: beakerlib
+tag:
+  - distribution
+recommend:
+  - dnsconfd
+  - dnsconfd-unbound

--- a/tests/upgrade_restart/test.sh
+++ b/tests/upgrade_restart/test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# Maximum acceptable time in seconds for a daemon-reload + try-restart cycle.
+# A healthy restart completes in under 1 second; the pre-fix hang was 45s.
+RESTART_TIMEOUT=10
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "set -o pipefail"
+        rlRun "dnsconfd config nm_enable" 0 "Installing dnsconfd"
+        rlServiceStart dnsconfd
+        rlRun "systemctl is-active dnsconfd" 0 "dnsconfd is running"
+        rlRun "systemctl is-active dnsconfd-unbound-control.path" 0 "path unit is running"
+    rlPhaseEnd
+
+    rlPhaseStartTest "daemon-reload plus service restart completes quickly"
+        for i in 1 2 3; do
+            rlLog "Run $i: daemon-reload + try-restart dnsconfd.service"
+            START_TIME=$(date +%s)
+            rlRun "systemctl daemon-reload" 0 "daemon-reload"
+            rlRun "systemctl try-restart dnsconfd.service" 0 "try-restart dnsconfd"
+            END_TIME=$(date +%s)
+            ELAPSED=$((END_TIME - START_TIME))
+            rlLog "Restart completed in ${ELAPSED}s"
+            rlAssertGreater "restart must finish within ${RESTART_TIMEOUT}s" $RESTART_TIMEOUT $ELAPSED
+            rlRun "systemctl is-active dnsconfd" 0 "dnsconfd is active after restart $i"
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "path unit not marked for restart in postun scriptlet"
+        rlRun "rpm -q --scripts dnsconfd-unbound > scriptlets.txt" 0 "Getting dnsconfd-unbound scriptlets"
+        rlRun "grep -q 'mark-restart-system-units.*dnsconfd-unbound-control.path' scriptlets.txt" 1 \
+            "path unit must NOT be marked for restart in postun"
+        rlLog "postuninstall scriptlet content:"
+        rlRun "cat scriptlets.txt"
+    rlPhaseEnd
+
+    rlPhaseStartTest "no coredump or timeout during restart"
+        CUR_TIME=$(date +%T)
+        rlRun "systemctl daemon-reload" 0 "daemon-reload"
+        rlRun "systemctl try-restart dnsconfd.service" 0 "try-restart dnsconfd"
+        sleep 2
+        rlRun "journalctl -u dnsconfd --since $CUR_TIME | grep -i 'timed out'" 1 \
+            "no timeout messages in journal"
+        rlRun "journalctl -u dnsconfd --since $CUR_TIME | grep -i 'SIGABRT'" 1 \
+            "no SIGABRT in journal"
+        rlRun "systemctl is-active dnsconfd" 0 "dnsconfd is active"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "journalctl -u dnsconfd" 0 "Saving dnsconfd logs"
+        rlRun "journalctl -u unbound" 0 "Saving unbound logs"
+        rlRun "journalctl -u dnsconfd-unbound-control.path" 0 "Saving path unit logs"
+        rlRun "journalctl -u dnsconfd-unbound-control.service" 0 "Saving control service logs"
+        rlServiceRestore dnsconfd
+        rlRun "dnsconfd config uninstall" 0 "Uninstalling dnsconfd privileges"
+        rlRun "rm -f scriptlets.txt"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 2.2.0 across build and package configuration.
  * Updated documentation with new version and release date.

* **Bug Fixes**
  * Corrected systemd post-uninstall behavior to prevent unnecessary unit restarts.

* **Tests**
  * Added validation tests for daemon-reload and service restart operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InfrastructureServices/dnsconfd/pull/146)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->